### PR TITLE
Fixed compilation problem in msvc

### DIFF
--- a/src/aes.h
+++ b/src/aes.h
@@ -148,14 +148,13 @@ extern "C" {
    * Call this when you're done to erase the round keys. */
   extern void cf_aes_finish(cf_aes_context *ctx);
 
+  /* .. c:var:: const cf_prp cf_aes
+   * Abstract interface to AES.  See :c:type:`cf_prp` for
+   * more information. */
+  extern const cf_prp cf_aes;
+
 #ifdef __cplusplus
 }
 #endif
-
-
-/* .. c:var:: const cf_prp cf_aes
- * Abstract interface to AES.  See :c:type:`cf_prp` for
- * more information. */
-extern const cf_prp cf_aes;
 
 #endif


### PR DESCRIPTION
LNK2001	unresolved external symbol "struct cf_prp_tag const cf_aes" (?cf_aes@@3Ucf_prp_tag@@B)